### PR TITLE
fix(app): drop deprecated tsconfig baseUrl

### DIFF
--- a/apps/bulwark-app/tsconfig.json
+++ b/apps/bulwark-app/tsconfig.json
@@ -11,7 +11,6 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Problem

`tsc` errors on `apps/bulwark-app/tsconfig.json`:

> Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption `"ignoreDeprecations": "6.0"` to silence this error.

## Fix

Delete the `"baseUrl": "."` line. This is the real migration rather than setting `ignoreDeprecations`, which would only defer the same error until TS 7.0 removes the option outright.

It's safe because nothing depended on `baseUrl`:

- Since TS 4.1, `paths` entries resolve relative to the tsconfig file's own directory, so the `"@/*" -> "./src/*"` mapping already means `apps/bulwark-app/src/*` without `baseUrl` anchoring it.
- Vite resolves the `@` alias at runtime through its own `resolve.alias` in `vite.config.ts` and never consulted tsconfig.

`baseUrl` also enabled bare-specifier resolution against the project root (e.g. `import x from "src/foo"` with no `@/` prefix). Nothing in the codebase used that — the clean typecheck confirms it.

## Verification

- `npx tsc --noEmit` — passes clean, no deprecation error. The `@/*` imports still resolve; had they not, this would have failed with `TS2307: Cannot find module` across the codebase.
- `npm run build` (`tsc && vite build`) — succeeds, emits `dist/assets/index-*.js` (291 kB) plus CSS/font assets.