### PR TITLE
chore(aur): checksum for 0.10.0

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -11,6 +11,6 @@ pkgbase = bulwarkctl
 	optdepends = clamav: antivirus scanning support
 	options = !lto
 	source = bulwarkctl-0.10.0.tar.gz::https://github.com/vietanhdev/bulwark/archive/refs/tags/v0.10.0.tar.gz
-	sha256sums = 3e5c6308c6f0f55d930656f8eb1d1c31b6473944885df2f7a58be60937d35713
+	sha256sums = f746759a0c0a0d70a8377c864c3dccae5c7e8d45bf846348fcf56fc27ebb7263
 
 pkgname = bulwarkctl

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -29,7 +29,7 @@ options=('!lto')
 # Bulwark prints a distro-aware install hint when it is absent.
 optdepends=('clamav: antivirus scanning support')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('3e5c6308c6f0f55d930656f8eb1d1c31b6473944885df2f7a58be60937d35713')
+sha256sums=('f746759a0c0a0d70a8377c864c3dccae5c7e8d45bf846348fcf56fc27ebb7263')
 
 prepare() {
   cd "bulwark-$pkgver"


### PR DESCRIPTION
The `PKGBUILD` pinned a placeholder sha256 (`3e5c…`) for the v0.10.0 source tarball. That checksum cannot be computed before the tag exists, so `bump-version.sh` emits a reminder rather than a value.

Now that v0.10.0 is published, refreshed to the real `f746…` and verified with a real `makepkg --verifysource` in an `archlinux:latest` container — "Validating source files with sha256sums... Passed" — rather than trusting the refresh script's own output.

Without this, an AUR user installing 0.10.0 hits a checksum mismatch.