### PR TITLE
build(deps): bump rand_regex to 0.19 and rand to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
  "diesel_migrations",
  "libc",
  "libsqlite3-sys",
- "rand 0.8.7",
+ "rand 0.10.2",
  "rand_regex",
  "rayon",
  "regex",
@@ -572,6 +572,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +716,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1544,6 +1564,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3056,33 +3077,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3097,15 +3108,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
@@ -3114,12 +3116,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_regex"
-version = "0.17.0"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfbd599a8c757f89100e3ae559fb1ef9efa1cfd9276136862e3089dec627b31"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_regex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e745eeef604742ec751000e44d91cdc0552aacacb2c74bee88cc7685918cfa"
 dependencies = [
- "rand 0.8.7",
+ "rand 0.10.2",
  "regex-syntax",
 ]
 
@@ -3620,7 +3628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4238,7 +4246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/bulwark-core/Cargo.toml
+++ b/crates/bulwark-core/Cargo.toml
@@ -34,6 +34,6 @@ tempfile = "3"
 # Generates a random string that matches a given regex — the same trick gitleaks uses (`reggen`) to
 # build a true positive for every rule from the rule's own pattern, so the test corpus stays in sync
 # with the rule pack and no secret-shaped literal is ever committed. Test-only, never shipped.
-rand = "0.8"
-rand_regex = "0.17"
+rand = "0.10"
+rand_regex = "0.19"
 regex-syntax = "0.8.11"

--- a/crates/bulwark-core/src/ai_scan/secrets.rs
+++ b/crates/bulwark-core/src/ai_scan/secrets.rs
@@ -1030,7 +1030,8 @@ pub fn redact_text_in(path: Option<&str>, text: &str) -> (String, usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{Rng, SeedableRng};
+    use rand::distr::Distribution;
+    use rand::SeedableRng;
     use std::collections::BTreeSet;
 
     const ALNUM: &str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -1186,7 +1187,10 @@ mod tests {
                 // Sample bytes, not a `String`: `rand_regex`'s `String` sampler *panics* on a
                 // non-UTF-8 draw, and with Unicode off that is routine. Bytes plus a `from_utf8`
                 // check turn a crash into "try the next seed".
-                let bytes: Vec<u8> = rand::rngs::StdRng::seed_from_u64(seed).sample(gen);
+                // rand 0.10 removed `Rng::sample`; sampling now runs the other way round, from
+                // the distribution given an rng.
+                let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+                let bytes: Vec<u8> = gen.sample(&mut rng);
                 let sample = String::from_utf8(bytes).ok()?;
                 self.verifier.is_match(&sample).then_some(sample)
             })


### PR DESCRIPTION
Supersedes #28, which fails CI on every platform.

`rand_regex` 0.19 requires `rand` 0.10; this crate pinned `rand` 0.8, so `Distribution` was not implemented for the `rand_regex::Regex` in scope. The bump cannot compile on its own — the two crates move together. `rand` 0.10 additionally removed `Rng::sample`, so the generator call is inverted to sample from the distribution.

**Why this needed care rather than a rubber stamp:** `rand_regex` generates the true-positive samples for the secret-detection pack. A build failure is loud; a generator that silently produces nothing usable would leave the pack with no real true-positive coverage while the suite stayed green — a quietly weaker secret detector.

`every_rule_detects_a_secret_generated_from_its_own_pattern` requires a generated match for every bundled rule, so degradation fails it rather than hiding. It passes, as does the vendored gitleaks false-positive corpus.

446 tests, clippy clean at `-D warnings`, fmt clean. `rand` is used in exactly two lines, both `#[cfg(test)]`.