### PR TITLE
build(deps): bump four pinned CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
           components: clippy, rustfmt
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
       - name: Install cargo-audit
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
 
@@ -231,7 +231,7 @@ jobs:
         working-directory: apps/bulwark-app
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm
@@ -250,7 +250,7 @@ jobs:
         working-directory: apps/bulwark-app
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -278,7 +278,7 @@ jobs:
         working-directory: docs
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
 

--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Attach bundle to release
         if: ${{ github.event.inputs.release_tag != '' }}
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ github.event.inputs.release_tag }}
           files: bulwark.flatpak

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           echo "version=${CARGO_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Building version ${CARGO_VERSION}"
 
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -128,7 +128,7 @@ jobs:
           # the resulting link errors would read like a source bug.
           key: ${{ matrix.arch }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         if: matrix.gui
         with:
           node-version: 20
@@ -317,7 +317,7 @@ jobs:
           - { image: "fedora:41",    pkg: rpm, gui: false, arch: aarch64, deb_arch: arm64, runner: ubuntu-24.04-arm }
     name: verify (${{ matrix.image }}, ${{ matrix.arch }})
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: bulwark-linux-${{ matrix.arch }}
           path: dist
@@ -439,7 +439,7 @@ jobs:
           - { arch: aarch64, multiarch: aarch64-linux-gnu, runner: ubuntu-24.04-arm }
     name: verify-appimage (${{ matrix.arch }})
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: bulwark-linux-${{ matrix.arch }}
           path: dist
@@ -513,7 +513,7 @@ jobs:
     name: verify-gui-launch (${{ matrix.arch }})
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: bulwark-linux-${{ matrix.arch }}
           path: build/relassets
@@ -539,7 +539,7 @@ jobs:
           set -euo pipefail
           echo "version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           # Every arch the build matrix produced, flattened into one dist/. Using a pattern
           # rather than naming the arches means adding a third one to the build matrix needs no
@@ -568,7 +568,7 @@ jobs:
       # public release.
       - name: Publish GitHub Release
         if: github.ref_type == 'tag'
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: dist/*
           draft: true


### PR DESCRIPTION
Combines dependabot #18, #19, #20 and #21.

| action | from | to |
|---|---|---|
| `actions/setup-node` | v4 | v7 |
| `actions/download-artifact` | v7 | v8 |
| `softprops/action-gh-release` | v3.0.1 | v3.0.2 |
| `dtolnay/rust-toolchain` | `fa04a14` | `2c7215f` |

**Why combined rather than merged individually:** three of the four touch `release.yml`, which only runs on tag. A green PR check says nothing about them. `download-artifact` is the step that collects every built artifact — break it and the release fails *after* everything has already compiled, which is the most expensive place to find out.

So this branch was rehearsed with a real `workflow_dispatch` run of `release.yml` (the trigger that exists for exactly this), exercising both architectures, `verify-install` across five distro images, `verify-appimage` and `verify-gui-launch` — without publishing. Merging once that run is green.

Closes #18, closes #19, closes #20, closes #21.