### PR TITLE
chore(release): 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,11 +368,11 @@ dependencies = [
 
 [[package]]
 name = "bulwark-agent"
-version = "0.10.0"
+version = "0.10.1"
 
 [[package]]
 name = "bulwark-app"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "bulwark-core",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "bulwark-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -419,11 +419,11 @@ dependencies = [
 
 [[package]]
 name = "bulwark-proto"
-version = "0.10.0"
+version = "0.10.1"
 
 [[package]]
 name = "bulwarkctl"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "bulwark-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 authors = ["Viet Anh Nguyen"]
 license = "Apache-2.0"

--- a/apps/bulwark-app/package.json
+++ b/apps/bulwark-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bulwark-app",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/apps/bulwark-app/src-tauri/tauri.conf.json
+++ b/apps/bulwark-app/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bulwark",
   "mainBinaryName": "bulwark-app",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "identifier": "com.vietanhdev.bulwark",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/bulwark-app/src/mocks/tauri/app.ts
+++ b/apps/bulwark-app/src/mocks/tauri/app.ts
@@ -1,6 +1,6 @@
 // Mock of @tauri-apps/api/app — see README.md.
 export async function getVersion(): Promise<string> {
-  return "0.10.0";
+  return "0.10.1";
 }
 
 export async function getTauriVersion(): Promise<string> {

--- a/crates/bulwarkctl/Cargo.toml
+++ b/crates/bulwarkctl/Cargo.toml
@@ -16,7 +16,7 @@ name = "bulwarkctl"
 path = "src/main.rs"
 
 [dependencies]
-bulwark-core = { path = "../bulwark-core", version = "0.10.0" }
+bulwark-core = { path = "../bulwark-core", version = "0.10.1" }
 clap.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulwark",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "description": "Bulwark — Linux host security scanner (Rust core + Tauri desktop app). Root convenience scripts that drive the desktop app under apps/bulwark-app.",
   "scripts": {

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = bulwarkctl
 	pkgdesc = Linux host security and misconfiguration scanner (CLI)
-	pkgver = 0.10.0
+	pkgver = 0.10.1
 	pkgrel = 1
 	url = https://github.com/vietanhdev/bulwark
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = bulwarkctl
 	depends = gcc-libs
 	optdepends = clamav: antivirus scanning support
 	options = !lto
-	source = bulwarkctl-0.10.0.tar.gz::https://github.com/vietanhdev/bulwark/archive/refs/tags/v0.10.0.tar.gz
+	source = bulwarkctl-0.10.1.tar.gz::https://github.com/vietanhdev/bulwark/archive/refs/tags/v0.10.1.tar.gz
 	sha256sums = f746759a0c0a0d70a8377c864c3dccae5c7e8d45bf846348fcf56fc27ebb7263
 
 pkgname = bulwarkctl

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -5,7 +5,7 @@
 # already ship). Only `bulwarkctl` is packaged — the Tauri GUI needs WebKitGTK and
 # is distributed as Flatpak/Snap/AppImage instead.
 pkgname=bulwarkctl
-pkgver=0.10.0
+pkgver=0.10.1
 pkgrel=1
 pkgdesc="Linux host security and misconfiguration scanner (CLI)"
 # Both architectures build from this one PKGBUILD unchanged — there is no arch-specific code

--- a/packaging/copr/bulwarkctl.spec
+++ b/packaging/copr/bulwarkctl.spec
@@ -17,7 +17,7 @@
 # project rather than of this file, so it does not travel with the spec — anyone
 # recreating the project must set it again.
 Name:           bulwarkctl
-Version:        0.10.0
+Version:        0.10.1
 Release:        1%{?dist}
 Summary:        Linux host security and misconfiguration scanner (CLI)
 

--- a/packaging/flatpak/com.vietanhdev.bulwark.metainfo.xml
+++ b/packaging/flatpak/com.vietanhdev.bulwark.metainfo.xml
@@ -108,6 +108,15 @@
   </branding>
 
   <releases>
+    <release version="0.10.1" date="2026-07-20">
+      <description>
+        <p>A maintenance release. There are no changes to how Bulwark behaves — it updates bundled dependencies and build tooling only.</p>
+        <ul>
+          <li>Updated the bundled monospace typeface</li>
+          <li>Updated internal build and test dependencies</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.10.0" date="2026-07-19">
       <description>
         <p>One-click fixes for common problems, and a view of how your machine measures up against PCI DSS, HIPAA and ISO 27001.</p>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: bulwark
 title: Bulwark
 base: core24
-version: '0.10.0'   # set by scripts/bump-version.sh (checked by scripts/check-packaging-consistency.sh)
+version: '0.10.1'   # set by scripts/bump-version.sh (checked by scripts/check-packaging-consistency.sh)
 summary: Linux security misconfiguration & intrusion scanner (GUI)
 description: |
   Bulwark scans a Linux host for security misconfigurations and intrusion


### PR DESCRIPTION
Maintenance release.

Everything since v0.10.0 is dependency and tooling: CI action pins (not shipped), the `rand`/`rand_regex` bump (test-only), the AUR checksum for 0.10.0, and one bundled monospace font package. **No behavioural change ships.**

The Flatpak release notes say so plainly rather than padding — Flathub renders them on the store page.

446 tests, clippy clean at `-D warnings`, fmt clean, packaging consistency PASS, all ten version declarations agree at 0.10.1.